### PR TITLE
Add background for .review-summary-form-wrapper

### DIFF
--- a/src/discussions.scss
+++ b/src/discussions.scss
@@ -106,7 +106,7 @@ body {
         border-bottom-color: $tag-bg-color !important;
     }
     .review-summary-form-wrapper {
-        background-color: #24292e !important;
+        background-color: $comment-bg !important;
     }
     .discussion-timeline-actions {
         background-color: $bg-color !important;

--- a/src/discussions.scss
+++ b/src/discussions.scss
@@ -105,6 +105,9 @@ body {
     .review-summary::before {
         border-bottom-color: $tag-bg-color !important;
     }
+    .review-summary-form-wrapper {
+        background-color: #24292e !important;
+    }
     .discussion-timeline-actions {
         background-color: $bg-color !important;
         border-color: $border-color !important;


### PR DESCRIPTION
When commencing a review, GitHub adds the review submission form on the discussions page.  This fixes the styling to remove the ugly white background and replace it with the typical comment background.

Before:
<img width="775" alt="Before screenshot" src="https://user-images.githubusercontent.com/5179191/56101912-7417a200-5edd-11e9-9b32-757920f2613d.png">

After:
<img width="778" alt="Screen Shot 2019-04-14 at 17 47 13" src="https://user-images.githubusercontent.com/5179191/56101917-7da10a00-5edd-11e9-8b15-3b48872e751d.png">