### PR TITLE
Don't override default color on labels page

### DIFF
--- a/dist/manifest.json
+++ b/dist/manifest.json
@@ -3,7 +3,7 @@
   "name": "Github Dark Theme",
   "short_name": "Github Dark Theme",
   "description": "A Dark theme for all of Github based on Atom One Dark.",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "applications": {
     "gecko": {
       "id": "{1dbe3fd3-f191-4a3b-a5d7-a6f95ed2aea1}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dark-theme",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "github-dark-theme",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "repository": "git@github.com:poychang/github-dark-theme.git",
   "author": "Poy Chang <poypost@gmail.com>",
   "contributors": [

--- a/src/discussions.scss
+++ b/src/discussions.scss
@@ -206,13 +206,6 @@ body {
             color: $text-color;
         }
     }
-    .IssueLabel{
-        color: $text-black-color !important;
-
-        a{
-            color: $text-black-color !important;
-        }
-    }
     .pagination-loader-container {
         background-color: $bg-color !important;
         background-image: url('./img/progressive-disclosure-line@2x.png') !important;

--- a/src/layout.scss
+++ b/src/layout.scss
@@ -86,7 +86,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    a:not(.IssueLabel--big) {
+    a:not(.IssueLabel):not(.IssueLabel--big) {
         color: $link-color !important;
     }
     .link-gray {

--- a/src/layout.scss
+++ b/src/layout.scss
@@ -86,7 +86,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    a {
+    a:not(.IssueLabel--big) {
         color: $link-color !important;
     }
     .link-gray {


### PR DESCRIPTION
GitHub unfortunately uses inline styling on the labels on the issues and labels page to alternate between black and white for contrast.  This sets the link styling to not override the default colors, maintaining better contrast.

Before:
<img width="426" alt="Screen Shot 2019-04-15 at 16 12 50" src="https://user-images.githubusercontent.com/5179191/56171272-86571600-5f99-11e9-967b-cc85bbe6b071.png">

After:
<img width="425" alt="Screen Shot 2019-04-15 at 16 13 54" src="https://user-images.githubusercontent.com/5179191/56171274-86571600-5f99-11e9-9236-f9cefed8c37d.png">