### PR TITLE
Fix color of function name in file diff "Jump to..." dropdown

### DIFF
--- a/src/elements.scss
+++ b/src/elements.scss
@@ -131,6 +131,10 @@ body {
                 background-color: $border-color !important;
             }
         }
+
+        .select-menu-item-text pre {
+            color: $text-color !important;
+        }
     }
     .label-select-menu .select-menu-item.js-navigation-item.selected {
         background: $tag-bg-color !important;


### PR DESCRIPTION
Before:
<img width="441" alt="Screen Shot 2019-05-06 at 05 04 51" src="https://user-images.githubusercontent.com/5179191/57223963-ae480100-6fbc-11e9-8e53-0f1246f17eb3.png">

After:
<img width="430" alt="Screen Shot 2019-05-06 at 05 05 10" src="https://user-images.githubusercontent.com/5179191/57223964-ae480100-6fbc-11e9-9bad-c7220c7fe4ad.png">
