### PR TITLE
Re-add Fix for Comment Text Color

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -182,6 +182,7 @@ body {
         border-color: $border-color !important;
     }
     .timeline-comment {
+        color: $text-color !important;
         background-color: $comment-bg !important;
         border-color: $border-color !important;
 


### PR DESCRIPTION
### Fixes #50 

This simple PR fixes issue #50 by re-adding the `color` rule to `.timeline-comment`.

I've tested the change locally and it seems to be working as intended.