### PR TITLE
Fix Issue Labels

### DIFF
--- a/src/theme/issues.scss
+++ b/src/theme/issues.scss
@@ -1,15 +1,21 @@
-.task-progress .progress-bar .progress {
-    background-color: $faded-link-color !important;
-}
+body {
+    .task-progress .progress-bar .progress {
+        background-color: $faded-link-color !important;
+    }
 
-.new-label {
-	background-color: $comment-bg !important;
+    .new-label {
+        background-color: $comment-bg !important;
 
-	.js-new-label-color {
-		color: $link-color !important;
-	}
-}
+        .js-new-label-color {
+            color: $link-color !important;
+        }
+    }
 
-.TimelineItem-break{
-	background-color: $bg-color !important;
+    .TimelineItem-body {
+        color: $text-color !important;
+    }
+
+    .TimelineItem-break {
+        background-color: $bg-color !important;
+    }
 }

--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -86,7 +86,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    a:not(.IssueLabel):not(.IssueLabel--big) {
+    a:not(.IssueLabel):not(.IssueLabel--big):not(.lh-condensed-ultra) {
         color: $link-color !important;
     }
     div.commit-build-statuses {


### PR DESCRIPTION
## Fixes #39 

This PR fixes the light link color in issue history labels, and the dark text on issue commit references.

Before:

![github-labels_before](https://user-images.githubusercontent.com/646561/64628662-6c3e2a00-d3b7-11e9-9386-69c978bf8bc4.png)


After:

![github-labels_after](https://user-images.githubusercontent.com/646561/64628685-73fdce80-d3b7-11e9-97cf-f2613d7def78.png)
