### PR TITLE
Don't overwrite color of boxes showing hex color result

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -300,7 +300,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    .Box {
+    :not(.markdown-body code) .Box {
         background-color: #31363f !important;
         border-color: $border-color !important;
     }


### PR DESCRIPTION
Issue was found while responding to another issue.  GitHub shows the color result of any hex color in a code block, however the theme overwrites any such color samples.  This PR fixes them by not applying the box styling to anything within a Markdown body's `<code>` blocks.

Before:
![Screenshot from 2019-09-10 19-48-20](https://user-images.githubusercontent.com/5179191/64664538-53a83100-d404-11e9-9454-f56411aed7b1.png)

After:
![Screenshot from 2019-09-10 19-48-05](https://user-images.githubusercontent.com/5179191/64664554-57d44e80-d404-11e9-8067-028fc6fca443.png)
