### PR TITLE
Re-enable commit build status colors

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -86,7 +86,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    a:not(.IssueLabel):not(.IssueLabel--big):not(.lh-condensed-ultra) {
+    :not(.commit-build-statuses) > a:not(.IssueLabel):not(.IssueLabel--big):not(.lh-condensed-ultra) {
         color: $link-color !important;
     }
     div.commit-build-statuses {


### PR DESCRIPTION
Before:
<img width="458" alt="Screen Shot 2019-09-17 at 03 42 29" src="https://user-images.githubusercontent.com/5179191/65035084-32ac7800-d8fd-11e9-9544-d18270583a3a.png">

After:
<img width="379" alt="Screen Shot 2019-09-17 at 03 42 19" src="https://user-images.githubusercontent.com/5179191/65035095-38a25900-d8fd-11e9-9c5e-beb24ac3bfa9.png">
