### PR TITLE
Remove end_of_line = crlf from .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,5 @@ root = true
 charset = utf-8
 indent_style = space
 indent_size = 4
-end_of_line = crlf
 insert_final_newline = true
 trim_trailing_whitespace = true


### PR DESCRIPTION
Unfortunately, this line causes issues with users on Unix-based systems that use just LF as their line ending.  Furthermore, it appears that line endings are stored as LF in this repository anyways (hence why my editor is having such issues).  To save contributors from this trouble, I've removed the EOL requirement.