### PR TITLE
Fix color samples in code blocks

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -300,7 +300,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    :not(.markdown-body code) .Box {
+    *:not(code) .Box {
         background-color: $block-bg !important;
         border-color: $border-color !important;
     }


### PR DESCRIPTION
A while ago I sent a PR to allow the color blocks to show their colors, however it looks like I hadn't done it properly.  This PR intends to fix that.