### PR TITLE
Images should not have a background color (fix)

### DIFF
--- a/src/theme/markdown.scss
+++ b/src/theme/markdown.scss
@@ -24,6 +24,9 @@ code {
     blockquote {
         border-color: $border-color !important;
     }
+    img {
+        background-color: transparent !important;
+    }
     code,
     tt {
         background-color: $tag-bg-color !important;


### PR DESCRIPTION
Looks like GitHub sets a background color by default.  This PR is a follow-up to #64 that, instead of removing the statement entirely, sets it to `transparent`.