### PR TITLE
Fixes: "Explore" background & Disabled Buttons

### DIFF
--- a/src/theme/elements.scss
+++ b/src/theme/elements.scss
@@ -65,10 +65,13 @@ body {
     .btn:disabled {
         background-color: $dropdown-bg !important;
         color: $link-color !important;
+        opacity: 0.5 !important;
+        cursor: not-allowed !important;
     }
     .btn-outline.disabled,
     .btn-outline:disabled {
         background-color: $dropdown-bg !important;
+        cursor: not-allowed !important;
     }
     .gh-header {
         background-color: transparent !important;

--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -391,8 +391,14 @@ body {
     .conversation-list-heading .inner {
         background: $dropdown-bg;
     }
-    .application-main .flex-wrap {
-        background-color: $bg-color !important;
+    .application-main {
+        .flex-wrap {
+            background-color: $bg-color !important;
+        }
+
+        & > main > div.border-bottom.border-gray-light {
+            background-color: $bg-color !important;
+        }
     }
     .note,
     .help {


### PR DESCRIPTION
#### Fixes #59 by overriding the white background on the [Explore page](https://github.com/explore)

#### Fixes #69 by adding a 50% opacity & disabled cursor to disabled buttons