### PR TITLE
Fixes #76 - Progress bars are reversed

### DIFF
--- a/src/theme/issues.scss
+++ b/src/theme/issues.scss
@@ -1,6 +1,10 @@
 body {
-    .task-progress .progress-bar .progress {
+    .task-progress .progress-bar{
         background-color: $faded-link-color !important;
+    }
+
+    .task-progress .progress-bar .progress {
+        background-color: $link-color !important;
     }
 
     .new-label {


### PR DESCRIPTION
This pull request fixes the progress bar found in Pull Requests and Issues on Github. It changes the sass variables used and introduces a new class into issue.scss. 

Before:
![image](https://user-images.githubusercontent.com/35984346/68995184-d01e1c80-0858-11ea-97cb-f4ccc6402d1b.png)

After:
![image](https://user-images.githubusercontent.com/35984346/68995188-d6ac9400-0858-11ea-83f4-d74073143391.png)
