### PR TITLE
fix: commit icon background

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -69,6 +69,9 @@ body {
         color: $text-color !important;
         border-color: $border-color !important;
     }
+    .TimelineItem.TimelineItem--condensed .TimelineItem-badge {
+        background: $bg-color !important;
+    }
     .timeline-commits .commit-message > code a {
         color: $text-color !important;
     }


### PR DESCRIPTION
This PR is an attempt to remove the background on PR commit icon. I'm not sure if I put the styles in the correct place, since the class selector I'm using is a bit weird compared to all the classes in the file.

Tested on Firefox as I can't reproduce it on Chrome.

---
How it looks on light mode
<img width="702" alt="Screen Shot 2019-11-21 at 12 54 50 PM" src="https://user-images.githubusercontent.com/25715018/69309013-4b6b3e00-0c5e-11ea-9036-96c383802d89.png">

How it currently looks on dark mode
<img width="706" alt="Screen Shot 2019-11-21 at 12 54 33 PM" src="https://user-images.githubusercontent.com/25715018/69309182-58882d00-0c5e-11ea-9e72-120d5e860875.png">

How it looks with the changes in this PR. (I think the icon color should be a bit lighter. Let me know what you think, I'm happy to look into it a bit more and make the change)
<img width="689" alt="Screen Shot 2019-11-21 at 12 50 15 PM" src="https://user-images.githubusercontent.com/25715018/69309854-88cfcb80-0c5e-11ea-9b5b-042e03b452dc.png">

