### PR TITLE
fix: text color of dashboard commit message

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -263,6 +263,9 @@ body {
     .commit-tease-sha {
         color: $link-color !important;
     }
+    .commits blockquote {
+        color: $text-color !important;
+    }
     .reponav-item {
         &:focus,
         &:hover {


### PR DESCRIPTION
A minor change to help make the commit message on GitHub dashboard more readable.

Before
<img width="530" alt="Screen Shot 2019-11-22 at 10 13 45 PM" src="https://user-images.githubusercontent.com/25715018/69437524-10f4c480-0d76-11ea-91df-54a927c70387.png">

After
<img width="531" alt="Screen Shot 2019-11-22 at 10 15 58 PM" src="https://user-images.githubusercontent.com/25715018/69437539-17833c00-0d76-11ea-9de8-2b743cf28c6f.png">

