### PR TITLE
styles(contributions/legend) dark color on 0 commits

### DIFF
--- a/src/theme/profile.scss
+++ b/src/theme/profile.scss
@@ -84,7 +84,7 @@
     .contrib-legend {
         li {
             &:nth-child(1) {
-                background-color: $contrib-color-1 !important;
+                background-color: $block-bg !important;
             }
             &:nth-child(2) {
                 background-color: $contrib-color-2 !important;

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -53,7 +53,7 @@ $scrollbar-thumb: rgba(85, 85, 85, 0.7);
 
 // Profile contributions graph variables
 $contrib-color: #196127;
-$contrib-color-1: #ebeaf0;
+$contrib-color-1: $block-bg;
 $contrib-color-2: lighten($contrib-color, 50%);
 $contrib-color-3: lighten($contrib-color, 30%);
 $contrib-color-4: lighten($contrib-color, 15%);


### PR DESCRIPTION
fixes #75 

# example
<img width="795" alt="Screenshot 2019-11-26 07 38 33" src="https://user-images.githubusercontent.com/4466585/69639475-2ee65180-1022-11ea-8373-0735b30864a0.png">
