### PR TITLE
fix: commit ref username color

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -247,6 +247,11 @@ body {
         background-color: $bg-color !important;
         background-image: url('./img/progressive-disclosure-line@2x.png') !important;
     }
+    .commit-ref {
+        .user {
+            color: $link-color !important;
+        }
+    }
 }
 
 .AvatarStack-body {


### PR DESCRIPTION
Small fix to make the username on commit ref more readable.
Tested on Chrome and Firefox.

Before
<img width="546" alt="Screen Shot 2019-11-26 at 9 35 18 PM" src="https://user-images.githubusercontent.com/25715018/69643091-62ae8f00-1095-11ea-8493-38338273c6b2.png">

After
<img width="550" alt="Screen Shot 2019-11-26 at 9 35 52 PM" src="https://user-images.githubusercontent.com/25715018/69643117-6c37f700-1095-11ea-9148-43cc2ea665fa.png">
