### PR TITLE
fix: link icon color

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -83,6 +83,10 @@ table.capped-list tr:nth-child(even) {
     color: #dbab09 !important;
 }
 
+.octicon.octicon-link {
+    color: $link-color !important;
+}
+
 /* Suggestions dropdown (i.e. Emoji Picker) */
 .suggester {
     background-color: $bg-color !important;


### PR DESCRIPTION
When hover on a link:

Before
<img width="331" alt="Screen Shot 2019-11-29 at 1 39 44 AM" src="https://user-images.githubusercontent.com/25715018/69827610-ad253c80-124a-11ea-81e9-e5e9b315533f.png">

After
<img width="348" alt="Screen Shot 2019-11-29 at 1 40 02 AM" src="https://user-images.githubusercontent.com/25715018/69827618-b7473b00-124a-11ea-9a18-0c780456d3bf.png">

