### PR TITLE
fix: user badge border color

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -91,6 +91,9 @@ body {
     .timeline-new-comment .timeline-comment::after {
         border-right-color: $tag-bg-color !important;
     }
+    .timeline-comment-label {
+        border-color: $text-color;
+    }
     .suggester-container .suggester {
         background: $dropdown-bg !important;
 


### PR DESCRIPTION
Small fix to make the border around user badge visible.

Before
<img width="154" alt="Screen Shot 2019-11-30 at 4 59 53 AM" src="https://user-images.githubusercontent.com/25715018/69891329-627cf080-132e-11ea-8ffc-15424c956c7a.png">

After
<img width="152" alt="Screen Shot 2019-11-30 at 5 00 35 AM" src="https://user-images.githubusercontent.com/25715018/69891332-67da3b00-132e-11ea-9b44-1d471f8da139.png">


