### PR TITLE
Fix background for discussion participants

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -59,6 +59,9 @@ body {
     .discussion-sidebar-heading {
         color: $text-color !important;
     }
+    .participation-avatars {
+        background: transparent !important;
+    }
     .timeline-comment-header {
         background-color: $border-color !important;
         color: $text-color !important;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5179191/70193337-b3d10b00-16b3-11ea-9cad-2c6689a8b1ef.png)

After:
![image](https://user-images.githubusercontent.com/5179191/70193355-c3505400-16b3-11ea-8ac0-a86508a5508c.png)
