### PR TITLE
fix: text color in suggestion box

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -96,3 +96,7 @@ table.capped-list tr:nth-child(even) {
         border-bottom: 1px solid $border-color !important;
     }
 }
+
+.jump-to-suggestion-name mark {
+    color: $bright-text-color !important;
+}


### PR DESCRIPTION
Makes the text in suggestion drop down more readable.

Before 
<img width="543" alt="Screen Shot 2019-12-06 at 5 55 15 PM" src="https://user-images.githubusercontent.com/25715018/70318114-def16100-1851-11ea-95ec-5c3aa79612b1.png">

After
<img width="545" alt="Screen Shot 2019-12-06 at 5 54 51 PM" src="https://user-images.githubusercontent.com/25715018/70318129-e9135f80-1851-11ea-8272-bd809590ceec.png">
