### PR TITLE
fix: show more button in recent activity section

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -227,6 +227,17 @@ body {
     .news .alert {
         border-top: 1px solid $border-color !important;
     }
+    .news .Details button {
+        border-top-color: $border-color !important;
+        
+        &:hover {
+            background: transparent !important; 
+            text-decoration: underline !important;
+        }
+    }
+    .news .Details-content--hidden li {
+        border-top-color: $border-color !important;
+    }
     .dashboard-notice {
         background-color: $block-bg !important;
         border: solid 1px $border-color !important;


### PR DESCRIPTION
Fixes the style of the `Show more` button in the Recent activity section.

### Before
The button has a background on hover
<img width="971" alt="Screen Shot 2019-12-06 at 6 38 19 PM" src="https://user-images.githubusercontent.com/25715018/70320942-8d98a000-1858-11ea-8029-ebc3cd9f5cd3.png">

And when the button is clicked, the hidden item is shown with a white top border
<img width="968" alt="Screen Shot 2019-12-06 at 6 38 28 PM" src="https://user-images.githubusercontent.com/25715018/70321099-08fa5180-1859-11ea-8607-97cd3529fafb.png">

### After
On hover, the button has no background and is underlined
<img width="974" alt="Screen Shot 2019-12-06 at 6 51 31 PM" src="https://user-images.githubusercontent.com/25715018/70321351-ae152a00-1859-11ea-8355-23723dfa080e.png">

On click, the hidden item shown with a black top border
<img width="971" alt="Screen Shot 2019-12-06 at 6 38 02 PM" src="https://user-images.githubusercontent.com/25715018/70321015-c5074c80-1858-11ea-96be-1b80adbc7337.png">
