### PR TITLE
fix: repo label

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -19,6 +19,12 @@ body {
         background: $head-bg !important;
         border-color: $border-color !important;
     }
+    /* Repo label (i.e. Private, Archived) */
+    .repohead .Label--outline,
+    .repo-list .Label--outline {
+        color: $text-color !important;
+        border-color: $light-border-color !important;
+    }
     .site-header {
         background: $head-bg !important;
         border-color: $border-color !important;


### PR DESCRIPTION
Makes the repo label more visible.
Tested on Chrome and Firefox.

---
### On repo page
Before
<img width="289" alt="Screen Shot 2019-12-15 at 4 10 04 AM" src="https://user-images.githubusercontent.com/25715018/70854629-cdaef100-1ef0-11ea-8932-edbf5762dd95.png">

After
<img width="293" alt="Screen Shot 2019-12-15 at 3 49 05 AM" src="https://user-images.githubusercontent.com/25715018/70854610-86c0fb80-1ef0-11ea-83fa-d8555242e518.png">

### On repo list
(You can use this link to test: https://github.com/mozilla?utf8=%E2%9C%93&q=search&type=&language=)

Before
<img width="690" alt="Screen Shot 2019-12-15 at 4 11 16 AM" src="https://user-images.githubusercontent.com/25715018/70854645-f9ca7200-1ef0-11ea-983d-874619ea1641.png">

After
<img width="702" alt="Screen Shot 2019-12-15 at 4 09 28 AM" src="https://user-images.githubusercontent.com/25715018/70854647-0222ad00-1ef1-11ea-83da-e4b827e08894.png">
