### PR TITLE
#103: Fix 'Busy' user status coloring

### DIFF
--- a/src/theme/elements.scss
+++ b/src/theme/elements.scss
@@ -204,15 +204,6 @@ body {
     .dropdown-header {
         color: $faded-link-color !important;
     }
-    .user-status-message-wrapper {
-        color: $link-color !important;
-    }
-    .user-status-emoji-only-header {
-        background-color: $bg-color !important;
-    }
-    .user-status-container {
-        border: none !important;
-    }
 }
 
 .cc-ext .pagehead-actions .cc-classic-cta a {

--- a/src/theme/profile.scss
+++ b/src/theme/profile.scss
@@ -42,6 +42,27 @@
     }
 }
 
+.user-status-message-wrapper {
+    color: $link-color !important;
+}
+.user-status-emoji-only-header {
+    background-color: $bg-color !important;
+}
+.user-status-container {
+    border: none !important;
+
+    .user-status-container-border-busy {
+        background-color: $bg-pending-color !important;
+        border-color: $bg-pending-color !important;
+
+        .user-status-message-wrapper {
+            .text-gray-dark {
+                color: $text-black-color !important;
+            }
+        }
+    }
+}
+
 .avatar-before-user-status {
     border: none !important;
 }


### PR DESCRIPTION
Fix the "Busy" user status background; see #103 for a before example.

This is what it looks like after the changes in this PR:
![fixed-status-bg](https://user-images.githubusercontent.com/646561/71520558-57ac7180-2882-11ea-9fd6-14cd84a13b03.png)