### PR TITLE
Fix Emoji Picker background

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -100,3 +100,22 @@ table.capped-list tr:nth-child(even) {
 .jump-to-suggestion-name mark {
     color: $bright-text-color !important;
 }
+
+/* Emoji Picker-specific */
+.js-emoji-picker {
+    .js-emoji-button {
+        // background-color: $bg-color !important;
+        // background: $button-bg-image !important;
+        background: radial-gradient(circle, #424549, #535659) !important;
+        color: $link-color !important;
+        justify-content: center !important;
+
+        &:hover {
+            background: radial-gradient(circle, #535659, #424549) !important;
+        }
+
+        &.selected-emoji {
+            background: $button-active-color !important;
+        }
+    }
+}


### PR DESCRIPTION
While working on #103, I noticed that the background of the emoji picker buttons are white:
![emoji-picker_bad](https://user-images.githubusercontent.com/646561/71521370-20d85a80-2886-11ea-9d13-80f054427c2f.png)


With this PR, the backgrounds now look like this:
![emoji-picker_good](https://user-images.githubusercontent.com/646561/71521384-2c2b8600-2886-11ea-907a-f82cb588a5e9.png)
