### PR TITLE
Style unread github beta notifications correctly

### DIFF
--- a/src/theme/notifications.scss
+++ b/src/theme/notifications.scss
@@ -25,3 +25,12 @@
         text-decoration: none;
     }
 }
+
+.notifications-list-item {
+    background-color: $dropdown-bg !important;
+    border-color: $border-color !important;
+}
+
+.notifications-list-item:hover {
+    background-color: $tag-bg-color !important;
+}


### PR DESCRIPTION
The beta v2 GitHub notifications are not being styled correctly. I'm only noticing the style issue on unread notifications, but I went ahead and styled all notifications with the new `notification-list-item` style the same way.