### PR TITLE
Add dark background to tabbed SelectMenu

### DIFF
--- a/src/theme/organization.scss
+++ b/src/theme/organization.scss
@@ -69,13 +69,19 @@
 
     /* For select menus with tabs, like the branch selector */
     .SelectMenu-filter,
-    .SelectMenu-tabs {
-        background: $block-bg;
+    .SelectMenu-tabs,
+    .SelectMenu-list,
+    .SelectMenu-modal {
+        background: $block-bg !important;
+    }
+
+    .SelectMenu-filter {
+        border-color: $block-bg !important;
     }
 
     .SelectMenu-tab[aria-selected="true"] {
-        color: white;
-        background: $block-bg;
-        border-color: $tag-bg-color;
+        color: $text-color !important;
+        background: $block-bg !important;
+        border-color: $tag-bg-color !important;
     }
 }

--- a/src/theme/organization.scss
+++ b/src/theme/organization.scss
@@ -66,4 +66,16 @@
             border-top: 1px solid $border-color !important;
         }
     }
+
+    /* For select menus with tabs, like the branch selector */
+    .SelectMenu-filter,
+    .SelectMenu-tabs {
+        background: $block-bg;
+    }
+
+    .SelectMenu-tab[aria-selected="true"] {
+        color: white;
+        background: $block-bg;
+        border-color: $tag-bg-color;
+    }
 }


### PR DESCRIPTION
There is an issue in the branch select menu where some elements are missing the dark background. This is how it looks right now:

![image](https://user-images.githubusercontent.com/2715751/73164682-ad2ea500-40f2-11ea-96b9-d5216e80fc00.png)

And this is how it looks with my changes:

![image](https://user-images.githubusercontent.com/2715751/73165432-0e0aad00-40f4-11ea-8621-168abf9aba0d.png)
