### PR TITLE
Fix background of page head due to media query

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -451,11 +451,12 @@ body {
         background-color: $bg-color !important;
     }
 }
+
 @media (min-width: 768px) {
     body {
-        &.page-responsive{
-            .pagehead{
-                background-color: $bg-color !important;
+        &.page-responsive {
+            .pagehead, .repohead.experiment-repo-nav {
+                background-color: $head-bg !important;
             }
         }
     }

--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -451,3 +451,12 @@ body {
         background-color: $bg-color !important;
     }
 }
+@media (min-width: 768px) {
+    body {
+        &.page-responsive{
+            .pagehead{
+                background-color: $bg-color !important;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes a little issue caused by a media query combined with an `!important` flag adding more value than the plugin's styling.

Before:
<img width="1920" alt="Screen Shot 2020-02-08 at 15 53 53" src="https://user-images.githubusercontent.com/5179191/74093774-9d687680-4a8b-11ea-85b9-4ec3992bdc1e.png">

After:
<img width="1920" alt="Screen Shot 2020-02-08 at 15 58 08" src="https://user-images.githubusercontent.com/5179191/74093788-cee14200-4a8b-11ea-9e56-458a4e1496f2.png">

