### PR TITLE
Fix color samples styling

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -325,7 +325,7 @@ body {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
     }
-    *:not(code) .Box {
+   .Box:not(.ml-1) {
         background-color: $block-bg !important;
         border-color: $border-color !important;
     }


### PR DESCRIPTION
This is a successor to #66.  In that earlier PR, I attempted to resolve an issue where color samples in comments would not show up.  Apparently, for some odd reason it's STILL not working right...  They say third time's the charm, though!  This PR intends to resolve this issue once and for all.

Before:
<img width="180" alt="Screen Shot 2020-04-09 at 14 22 03" src="https://user-images.githubusercontent.com/5179191/78942836-5ab52180-7a6f-11ea-91d7-916dcbf4a746.png">

After:
<img width="180" alt="Screen Shot 2020-04-09 at 14 27 22" src="https://user-images.githubusercontent.com/5179191/78942844-5db01200-7a6f-11ea-9aba-686118af2d70.png">
