### PR TITLE
Fix corners around "close issue" and "comment" buttons

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -255,6 +255,10 @@ body {
             color: $link-color !important;
         }
     }
+
+    #partial-new-comment-form-actions div.bg-gray-light {
+        background-color: transparent !important;
+    }
 }
 
 .AvatarStack-body {


### PR DESCRIPTION
Before:
<img width="652" alt="Screen Shot 2020-04-09 at 15 08 25" src="https://user-images.githubusercontent.com/5179191/78945179-7cfd6e00-7a74-11ea-8002-8eccdf6f0ddd.png">

After:
<img width="652" alt="Screen Shot 2020-04-09 at 15 08 16" src="https://user-images.githubusercontent.com/5179191/78945184-81298b80-7a74-11ea-870b-e48f24fe007c.png">
