### PR TITLE
Add gitako extension dark colors

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
         "Poy Chang <poypost@gmail.com>",
         "Tariq <tariq.86@pm.me>",
         "Vladimir Mikhaylovskiy <vlad@indiegogo.com>",
-        "Vinyl Darkscratch <vinyldarkscratch@gmail.com> (https://www.queengoob.org)"
+        "Vinyl Darkscratch <vinyldarkscratch@gmail.com> (https://www.queengoob.org)",
+        "Benjamin Caradeuc <benjamin@caradeuc.info> (https://benjamin.caradeuc.info)"
     ],
     "scripts": {
         "serve": "live-server",

--- a/src/theme/app.scss
+++ b/src/theme/app.scss
@@ -19,5 +19,6 @@
 @import 'developer.scss';
 @import 'extensions/sourcegraph-ext.scss';
 @import 'extensions/octotree-ext.scss';
+@import 'extensions/gitako-ext.scss';
 @import 'extensions/better-pull-request-for-github-ext.scss';
 @import 'alert.scss';

--- a/src/theme/extensions/gitako-ext.scss
+++ b/src/theme/extensions/gitako-ext.scss
@@ -1,0 +1,104 @@
+/* # Gitako Extension */
+
+.gitako-toggle-show-button-wrapper {
+    .action-icon {
+        color: $link-color!important;
+    }
+
+    &.collapsed {
+        background-color: $tag-bg-color !important;
+        border-color: $border-color !important;
+
+        .action-icon {
+            color: $link-color !important;
+        }
+    }
+}
+
+.gitako-side-bar {
+    .gitako-side-bar-body {
+        background-color: $bg-color !important;
+        border: $border-color !important;
+        color: $text-color !important;
+
+        .octicon {
+            color: $link-color !important;
+        }
+
+
+        .gitako-side-bar-content {
+            .meta-bar {
+                background-color: $dropdown-bg !important;
+                border-color: $border-color !important;
+            }
+
+            .search-input {
+                border: none !important;
+                background-color: $tag-bg-color !important;
+
+                input {
+                        color: $text-color !important;
+                }
+            }
+
+            .file-explorer .node-item{
+                background-color: $comment-bg !important;
+                border-color: $border-color !important;
+                color: $text-color !important;
+
+                &.focused,
+                &:hover {
+                    background-color: $file-row-active-bg !important;
+                }
+            }
+        }
+
+        .gitako-settings-bar {
+            background-color: $bg-color !important;
+            border-color: $border-color !important;
+            color: $text-color !important;
+
+            .header-row {
+                background-color: $dropdown-bg !important;
+                border-color: $border-color !important;
+            }
+
+            .gitako-settings-bar-title {
+                border-color: $border-color !important;
+            }
+
+            .shadow-shelter {
+                background-color: $bg-color !important;
+            }
+
+            .TextInput-wrapper,
+            select,
+            button {
+                background-color: #424549 !important;
+                border-color: $border-color !important;
+                color: $text-color !important;
+                box-shadow: none !important;
+            }
+
+            button {
+                background-image: $button-bg-image !important;
+
+                &:hover:not(:disabled) {
+                    background-image: $button-bg-image-hover !important;
+                    background-position: 0 !important;
+                }
+
+                &:disabled {
+                    color: $link-color !important;
+                    opacity: 0.5 !important;
+                    cursor: not-allowed !important;
+                }
+            }
+        }
+    }
+
+    .gitako-resize-handler {
+        background-color: $border-color !important;
+        border-color: $border-color !important;
+    }
+}


### PR DESCRIPTION
Hi!

I am using github with this theme everyday and began using the [Gitako extension](https://chrome.google.com/webstore/detail/gitako/giljefjcheohhamkjphiebfjnlphnokk) instead of octotree.

I tried to add a dark theme to the extension here: https://github.com/EnixCoda/Gitako/pull/61 but that ended up not being in the maintainer's plan because of the fact that Gitako is developped with the idea that it should look like being part of the actual github website. (I understand it very well, but want that extension to look good too with this github theme!)

Here is my proposal:

![image](https://user-images.githubusercontent.com/5999900/80535057-793c7780-89a0-11ea-869a-491f7a2e1b40.png)
