### PR TITLE
Added hover for LI in notifications/subscriptions

### DIFF
--- a/src/theme/notifications.scss
+++ b/src/theme/notifications.scss
@@ -33,7 +33,7 @@ li.notifications-list-item {
 }
 
 .notifications-list-item:hover,
-li.notifications-list-item:hover {
+li.notifications-list-item:hover,
+.Box-row--hover-gray:hover {
     background-color: $tag-bg-color !important;
 }
-


### PR DESCRIPTION
Not sure if this is the correct file, but this is "notifications".

To reproduce:
1. Go to https://github.com/notifications/subscriptions.
1. Hover an item in the "Subscriptions" list.
1. Note that the background is almost white for :hover, it's not being overridden.