### PR TITLE
Added support for search result highlighting

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -407,6 +407,9 @@ body {
     .bg-gray-light {
         background-color: $tag-bg-color !important;
     }
+    .bg-yellow-light {
+        background-color: #473f00 !important;
+    }
     .tag-info {
         color: $link-color !important;
         .tag-name {


### PR DESCRIPTION
Was previously difficult to see:

![image](https://user-images.githubusercontent.com/29358863/82100303-406f0300-9701-11ea-99e6-706376494b50.png)

Now looks like this:

![image](https://user-images.githubusercontent.com/29358863/82100306-44028a00-9701-11ea-979b-23bf852a3423.png)
