### PR TITLE
fix: text color of task progress counts

### DIFF
--- a/src/theme/issues.scss
+++ b/src/theme/issues.scss
@@ -7,6 +7,10 @@ body {
         background-color: $link-color !important;
     }
 
+    .task-progress .task-progress-counts {
+        color: $text-color !important;
+    }
+
     .new-label {
         background-color: $comment-bg !important;
 


### PR DESCRIPTION
Make the text of the checklist item count more readable.

Screenshot of a PR, but this change works with issues as well.

Before
<img width="564" alt="Screen Shot 2020-06-04 at 4 04 10 PM" src="https://user-images.githubusercontent.com/25715018/83737528-52e3b900-a67d-11ea-9be4-2e401dadd187.png">

After
<img width="551" alt="Screen Shot 2020-06-04 at 4 07 16 PM" src="https://user-images.githubusercontent.com/25715018/83737642-7c9ce000-a67d-11ea-9d81-3602c85849ed.png">

