### PR TITLE
Added support for active search field text colour

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -54,7 +54,7 @@ body {
         border-color: $border-color !important;
         color: $link-color !important;
     }
-    .header-search-current .jump-to-field-active {
+    .jump-to-field-active {
         color: $link-color !important;
     }
     .flash {

--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -54,6 +54,9 @@ body {
         border-color: $border-color !important;
         color: $link-color !important;
     }
+    .header-search-current .jump-to-field-active {
+        color: $link-color !important;
+    }
     .flash {
         background-color: $tag-bg-color !important;
         color: $link-color !important;


### PR DESCRIPTION
The text in the search field when it was active used to be almost invisible:

![image](https://user-images.githubusercontent.com/29358863/83941010-d3bac600-a7df-11ea-9661-89624788a23d.png)

This makes it the normal text colour:

![image](https://user-images.githubusercontent.com/29358863/83941012-d6b5b680-a7df-11ea-8e5d-52189cb20994.png)