### PR TITLE
Fix network tree lines in Forks view

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -52,6 +52,11 @@ table.capped-list tr:nth-child(even) {
     background-color: $private-bg !important;
 }
 
+img.network-tree {
+    filter: invert(1);
+    mix-blend-mode: lighten;
+}
+
 /* Marketplace */
 
 .MarketplaceSideNav {


### PR DESCRIPTION
Hey there!
This inverts the network tree lines in the Forks view.

Before:
![Before](https://user-images.githubusercontent.com/5791070/85231486-a5500400-b3f7-11ea-9faf-bff285fb6b49.png)

After:
![After](https://user-images.githubusercontent.com/5791070/85231487-a7b25e00-b3f7-11ea-97c7-823bb1c45e7c.png)
