### PR TITLE
Fixed incorrect background color on team discussion comments

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -20,6 +20,10 @@ body {
             }
         }
     }
+
+    .discussion-post .timeline-inline-comments {
+        background: $comment-bg !important;
+    }
     .discussion-item-header {
         color: $text-color !important;
     }


### PR DESCRIPTION
As noted in https://github.com/poychang/github-dark-theme/issues/137 the backgrounds for comments on team discussions weren't being picked up. I added this functionality to fix the anomaly.

| Before  | After |
| ------------- | ------------- |
| ![Before](https://i.imgur.com/KFqzY0t.png) | ![After](https://i.imgur.com/sKQkXp6.png)  |

