### PR TITLE
Fix comment form tab

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -15,8 +15,9 @@ body {
         .tabnav-tab {
             &.selected,
             &[aria-selected='true'] {
-                background: $bg-color !important;
-                color: $text-color !important;
+                background: $comment-bg !important;
+                color: $link-color !important;
+                border-color: $border-color;
             }
         }
     }
@@ -231,6 +232,7 @@ body {
     }
     .merge-status-item {
         background-color: $bg-color !important;
+        border-color: $border-color !important;
     }
     .gh-header-number {
         color: $faded-link-color;


### PR DESCRIPTION
This fixes the tab appearance in the comment form.

Before:
![Before](https://user-images.githubusercontent.com/5791070/85269886-d3295d00-b478-11ea-943c-9fad5deb701c.png)

After:
![After](https://user-images.githubusercontent.com/5791070/85269899-d6244d80-b478-11ea-858b-8551982420a3.png)
