### PR TITLE
Color to status badge

### DIFF
--- a/src/theme/profile.scss
+++ b/src/theme/profile.scss
@@ -43,6 +43,9 @@
     }
 }
 
+.user-status-circle-badge {
+    background-color: $block-bg !important;
+}
 .user-status-message-wrapper {
     color: $link-color !important;
 }


### PR DESCRIPTION
I changed the color of the status badge use the color $block-bg instead the default of light theme
![image](https://user-images.githubusercontent.com/34684860/85800328-23bde600-b717-11ea-93dc-3447e17dabca.png)
