### PR TITLE
Fix sponsors menu item and introction background color

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -22,6 +22,10 @@ body {
         }
     }
 
+    .comment-form-head.tabnav {
+        background-color: $dropdown-bg !important;
+    }
+
     .discussion-post .timeline-inline-comments {
         background: $comment-bg !important;
     }

--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -75,6 +75,7 @@ body {
     }
     .menu-item {
         border-bottom: 1px solid $border-color !important;
+        background-color: $dropdown-bg !important;
     }
     .menu-item:hover {
         background-color: #41464f !important;


### PR DESCRIPTION
Fixed https://github.com/poychang/github-dark-theme/issues/209 where introduction navbar and menu tiles have the incorrect background color

Before | After
------------ | -------------
![Before menu items](https://i.imgur.com/oRlbvSI.png) | ![After menu items](https://i.imgur.com/sIX97ar.png)


Before | After
------------ | -------------
![Before introduction navbar](https://i.imgur.com/iDGQsFt.png) | ![After introduction navbar](https://i.imgur.com/kmAmYKn.png)