### PR TITLE
Fix render notice text and background color

### DIFF
--- a/src/theme/elements.scss
+++ b/src/theme/elements.scss
@@ -177,6 +177,11 @@ body {
     .Popover-message:after {
         border-bottom-color: $block-bg !important;
     }
+
+    .render-notice {
+        background-color: $dropdown-bg !important;
+        color: $text-color !important;
+    }
 }
 
 .cc-ext .pagehead-actions .cc-classic-cta a {


### PR DESCRIPTION
I've never seen this element before but I was browsing some files in a private repo of mine and I saw this popup. It's in a private repo so I can't exactly share the link but I took before and after pictures to show the fix.


Before | After
------------ | -------------
![Before render fix](https://i.imgur.com/clri8YK.png) | ![After render fix](https://i.imgur.com/0wwOgtV.png)
