### PR TITLE
Add github original streak ext styling

### DIFF
--- a/src/theme/app.scss
+++ b/src/theme/app.scss
@@ -18,6 +18,7 @@
 @import 'developer.scss';
 @import 'extensions/sourcegraph-ext.scss';
 @import 'extensions/octotree-ext.scss';
+@import 'extensions/githuboriginalstreak-ext.scss';
 @import 'extensions/gitako-ext.scss';
 @import 'extensions/better-pull-request-for-github-ext.scss';
 @import 'extensions/hovercard-ext.scss';

--- a/src/theme/extensions/githuboriginalstreak-ext.scss
+++ b/src/theme/extensions/githuboriginalstreak-ext.scss
@@ -1,0 +1,5 @@
+/* Github original streak extension */
+
+.contrib-number, .text-muted {
+    color: $text-color !important;
+}


### PR DESCRIPTION
Closes https://github.com/poychang/github-dark-theme/issues/236

Adds dark mode styling to the text used in the Github Original Streaks extension. I saw that other extensions are supported but I am not sure if making a whole new `.scss` file is needed as it's just two lines overall. I'd be fine with not having this included if it's not too much of an important extension to add a fix for.

Before | After
------------ | -------------
![Before](https://i.imgur.com/888M7PE.png)| ![After](https://i.imgur.com/RTELXXk.png)  |