### PR TITLE
add color style for team title in invite people to organization page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "github-dark-theme",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "github-dark-theme",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "description": "change appearance of all GitHub pages to a dark theme",
     "license": "MIT",
     "author": "Poy Chang <poypost@gmail.com>",

--- a/src/manifest/manifest-chrome.json
+++ b/src/manifest/manifest-chrome.json
@@ -3,7 +3,7 @@
     "name": "GitHub Dark Theme",
     "short_name": "GitHub Dark Theme",
     "description": "A Dark theme for all of GitHub based on Atom One Dark.",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "browser_action": {
         "default_icon": "icons/icon.png",
         "default_popup": "app/popup.html"

--- a/src/manifest/manifest-edge.json
+++ b/src/manifest/manifest-edge.json
@@ -3,7 +3,7 @@
     "name": "GitHub Dark Theme",
     "short_name": "GitHub Dark Theme",
     "description": "A Dark theme for all of GitHub based on Atom One Dark.",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "browser_action": {
         "default_icon": "icons/icon.png",
         "default_popup": "app/popup.html"

--- a/src/manifest/manifest-firefox.json
+++ b/src/manifest/manifest-firefox.json
@@ -3,7 +3,7 @@
     "name": "GitHub Dark Theme",
     "short_name": "GitHub Dark Theme",
     "description": "A Dark theme for all of GitHub based on Atom One Dark.",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "applications": {
         "gecko": {
             "id": "{1dbe3fd3-f191-4a3b-a5d7-a6f95ed2aea1}"

--- a/src/manifest/manifest-ref.json
+++ b/src/manifest/manifest-ref.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "Chrome Extension TypeScript Starter",
     "description": "Chrome Extension, TypeScript, Visual Studio Code",
-    "version": "1.1.12",
+    "version": "1.1.13",
     "options_ui": {
         "page": "options.html",
         "chrome_style": true

--- a/src/theme/organization.scss
+++ b/src/theme/organization.scss
@@ -212,3 +212,7 @@
     background-color: $bg-color !important;
     color: $text-color !important;
 }
+
+.team-name{
+    color: $text-color !important;
+}


### PR DESCRIPTION
fixed #249 

added color style to the team title.

Before
=======
![chrome_QUEN2tPzrS](https://user-images.githubusercontent.com/11781291/94232564-3e377380-ff41-11ea-85df-410db5febd70.png)

After
=======
![スクリーンショット 2020-09-29 1 30 29](https://user-images.githubusercontent.com/11781291/94460607-f2602500-01f3-11eb-90b8-b7e473c149c9.png)
