### PR TITLE
Fix background for verified commit signature

### DIFF
--- a/src/theme/elements.scss
+++ b/src/theme/elements.scss
@@ -191,3 +191,7 @@ body {
 .pagehead-actions > li {
     color: $bright-text-color !important;
 }
+
+.signed-commit-header {
+    background-color: $dropdown-bg !important;
+}


### PR DESCRIPTION
Closes https://github.com/poychang/github-dark-theme/issues/248

Before | After
------------ | -------------
![Before](https://i.imgur.com/qbjk2A0.png) | ![After](https://i.imgur.com/lcV6PKa.png)  |