### PR TITLE
Apply green color to (currently grey) passing github actions build steps

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -202,3 +202,7 @@ img.network-tree {
         }
     }
 }
+/* Github actions success/failure indicator */
+.octicon-check-circle-fill {
+    color: $text-green-color !important;
+}


### PR DESCRIPTION
Most of the UI updates from the [recent github actions update](https://github.blog/2020-09-23-a-better-logs-experience-with-github-actions/) have been great. The only thing I do not like is that before with passing builds the indicator was an eye-catching green color wheras now they are just a monotone grey. I much prefer the green indicators for passing steps compared to the current grey indicators as it's just more pleasing visually.

There probably isn't much to debate about over this but I'd like to hear someone else's opinion if it goes against my own.

Before | After
------------ | -------------
![Before](https://i.imgur.com/AAk7Rzl.png) | ![After](https://i.imgur.com/6GuZHya.png)  |