### PR TITLE
fix CSS selector for private and archive label. 

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -31,10 +31,12 @@ body {
         border-color: $border-color !important;
     }
     /* Repo label (i.e. Private, Archived) */
-    .repohead .Label--outline,
-    .repo-list .Label--outline {
-        color: $text-color !important;
-        border-color: $light-border-color !important;
+    .Label {
+        &.Label--outline,
+        &.Label--gray {
+            color: $text-color !important;
+            border-color: $light-border-color !important;
+        }
     }
     .site-header {
         background: $head-bg !important;


### PR DESCRIPTION
## Description
Fixed #254 

As a result of modifying the CSS selector, it is displayed as follows now.

## Archived
### List
![image](https://user-images.githubusercontent.com/57127872/95418743-1ef20a80-0973-11eb-8e54-a30495e0344b.png)

### Detail
![image](https://user-images.githubusercontent.com/57127872/95418911-71cbc200-0973-11eb-80f0-ab694d72bce4.png)

## Private
### List
![image](https://user-images.githubusercontent.com/57127872/95419220-1e0da880-0974-11eb-8994-f217e4510566.png)

### Detail
![image](https://user-images.githubusercontent.com/57127872/95419323-6036ea00-0974-11eb-85d5-6f82b847e88a.png)
