### PR TITLE
Fix OAuth sign in screen

### DIFF
--- a/src/theme/auth.scss
+++ b/src/theme/auth.scss
@@ -24,3 +24,23 @@
 .logo-upload-container .upload-state p {
     color: $link-color !important;
 }
+
+#js-pjax-container {
+    background-color: $bg-color !important;
+}
+
+.permission-title {
+    color: $text-color !important;
+}
+
+.oauth-org-access-details {
+    background-color: $block-bg !important;
+}
+
+body.logged-in {
+    background-color: $bg-color !important;
+}
+
+.limited-access-emails, span.read-access {
+color: $text-color !important;
+}


### PR DESCRIPTION
Closes https://github.com/poychang/github-dark-theme/issues/135

Before | After
------------ | -------------
![Before](https://i.imgur.com/jFaudQl.png) | ![After](https://i.imgur.com/lYK3Kb4.png)  |

I'm currently taking part in hacktoberfest and I've seen a hacktoberfest tag on another PR in this repo. In order for a PR to be counted towards the PRs counted by hacktoberfest the guidelines say that PRs count if:

*  The repository has the `hacktoberfest` topic 
or
*  The individual PR has the `hacktoberfest-accepted` label. 

I'd appreciate it if could apply the `hacktoberfest-accepted` label as it's the easier of the two. If not then that's fine.