### PR TITLE
added styling around ".js-jump-to-badge"

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -384,6 +384,13 @@ body {
     .header-search-current .jump-to-field-active {
         color: $text-color !important;
     }
+
+    .js-jump-to-badge-search-text-default,
+    .js-jump-to-badge-search-text-global,
+    .js-jump-to-badge-jump {
+        color: $text-color !important;
+    }
+
     .code-list .code-list-item + .code-list-item {
         border-color: $border-color !important;
     }


### PR DESCRIPTION
closes #263

I created this pull request to improve the visibility of the incremental search window (I assigned a slightly lighter gray to the darker gray. This color as `$text-color` is used in many places as a common text color.)
However, I don't want to violate the styling rules, so I'd like to discuss it.
Regards.