### PR TITLE
Change The Background Of The Languages Indicators 

### DIFF
--- a/src/theme/repo.scss
+++ b/src/theme/repo.scss
@@ -87,6 +87,10 @@ body {
             color: $text-color !important;
         }
     }
+
+    .Progress{
+        background-color: $bg-color;
+    }
 }
 
 .text-mono {


### PR DESCRIPTION
## About the PR
I'm sorry if this is not the right way to go about adding a feature but I didn't see a contributing.md file. I installed the extension and noticed that the bars between the language usage indicators were still white so I decided to have a look around and fix it. It's a pretty simple three-line change but I feel like it makes the extension feel much more polished. 

## Example of the change made
### Before
![Before](https://user-images.githubusercontent.com/13850831/96668561-72783700-1329-11eb-8b85-95234ce5a056.png)

### After
![After](https://user-images.githubusercontent.com/13850831/96668572-7ad07200-1329-11eb-86e0-4d29a8f2869e.png)
