### PR TITLE
Fix mono text in box header

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -441,6 +441,9 @@ body {
     .Box-header {
         background-color: $dropdown-bg !important;
         border-color: $border-color !important;
+        .text-mono{
+            background-color: $dropdown-bg !important;
+        }
     }
     .conversation-list-heading {
         border-color: $border-color !important;


### PR DESCRIPTION
## About the PR
Another simple change that changes the box header so it dosnt have a buggy feeling background that looks out of place.

## Example of the change made
### Before
![Before](https://user-images.githubusercontent.com/13850831/96670081-8c674900-132c-11eb-9071-7f5cc84d4818.png)

### After
![After](https://user-images.githubusercontent.com/13850831/96670090-912bfd00-132c-11eb-9c48-5a6943a6f16e.png)