### PR TITLE
update repo.css to correct the background color mismatch.

### DIFF
--- a/src/theme/repo.scss
+++ b/src/theme/repo.scss
@@ -94,5 +94,5 @@ body {
 }
 
 .text-mono {
-    background: $bg-color !important;
+    background: $dropdown-bg !important;
 }


### PR DESCRIPTION
close #267 

Hi, I've been trying to come up with a solution to the above problem.
My personal view is that a CSS class called `text-mono` used to be assigned a variable called `$bg-color` in the commit here (https://github.com/poychang/github-dark-theme/commit/a9c258f86b3c680b2b8b90f473bc4b73a38fd6b6). 

But now, the background color doesn't match, and I think the color `$dropdown-bg` is closer to that.
But I haven't verified whether it is the correct color or not.
I think it's probably the same color.

If you need to discuss this, I'd be happy to reply to you.
Thank you for letting me use your software here.

Best regard.