### PR TITLE
update misc.css to fix color around dismiss button.

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -173,7 +173,7 @@ img.network-tree {
 
 /* Sponsors notice | Issue-#140 */
 .js-notice .js-notice-dismiss {
-    background: $block-bg !important;
+    background: $bg-color !important;
 }
 
 /* Invite teammates | Issue-#163 */


### PR DESCRIPTION
Close #268 (Already Closed)

The issue has already been closed, but I've created a fix for the issue in #268, so please take a look at it.
This problem is called [`Issue-#140`](https://github.com/poychang/github-dark-theme/issues/140)(Link) which seems to have been fixed once in the past.
The commit made for the correction that is [`02d963e`](https://github.com/poychang/github-dark-theme/commit/02d963e014e391f0f055f86f5ee819348ad75d3c)(Link).

### Before
![image](https://user-images.githubusercontent.com/57127872/97080326-811a6300-1635-11eb-8042-149f96324b22.png)

### After
![image](https://user-images.githubusercontent.com/57127872/97080370-b1fa9800-1635-11eb-8b7d-92e29fe45a60.png)

If there are any errors in the proposal, please let me know.

Thank you so much for this open-source project.