### PR TITLE
Update the background color on discussions page

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -191,7 +191,7 @@ body {
         border-color: $border-color !important;
     }
     .diffbar {
-        background-color: transparent !important;
+        background-color: $bg-color !important;
 
         .stale-files-tab {
             background-color: $bg-color !important;


### PR DESCRIPTION
So, I was checking the extension and I realized about this small transparency on the sticky header on the discussions page where the information about the files modified is shown, I fixed the transparency by setting the background color with the main background variable

![Screen Shot 2020-10-28 at 8 32 48 AM](https://user-images.githubusercontent.com/16256575/97442847-4bf16780-18f8-11eb-8876-df99bf876a9f.png)