### PR TITLE
Removed gradient background-image of .flash items

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -67,6 +67,7 @@ body {
     }
     .flash {
         background-color: $tag-bg-color !important;
+        background-image: none !important;
         color: $link-color !important;
     }
     .blankslate {


### PR DESCRIPTION
Fixes #291

Before:
![image](https://user-images.githubusercontent.com/1510856/98409660-8df67800-2073-11eb-818f-ff8bb11586e3.png)

After:
![image](https://user-images.githubusercontent.com/1510856/98409692-9949a380-2073-11eb-9a16-cad13ce1f41c.png)
