### PR TITLE
Fix discussions reply header color

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -296,4 +296,12 @@ body {
     .write-content {
         background-color: transparent !important;
     }
+
+    .js-timeline-marker {
+        background-color: $bg-color !important;
+    }
+
+    .clearfix {
+        background-color: $bg-color !important;
+    }
 }


### PR DESCRIPTION
Closes https://github.com/poychang/github-dark-theme/issues/308

Before | After
------------ | -------------
![Before](https://i.imgur.com/8k2kDtf.png) | ![After](https://i.imgur.com/tBYnyUT.png)  |
