### PR TITLE
fix: make the indicator for unread items visible

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -69,6 +69,9 @@ body {
     .Box-row--focus-gray.navigation-focus {
         background-color: $block-bg !important;
     }
+    .Box-row--unread {
+        box-shadow: 2px 0 0 $unread-border-color inset !important;
+    }
     .discussion-sidebar-item + .discussion-sidebar-item {
         border-color: $border-color !important;
     }

--- a/src/theme/variables.scss
+++ b/src/theme/variables.scss
@@ -71,3 +71,6 @@ $contrib-color-3: lighten($contrib-color, 15%);
 $contrib-color-4: lighten($contrib-color, 30%);
 $contrib-color-5: lighten($contrib-color, 50%);
 */
+
+// Blue stripe on unread item
+$unread-border-color: #0366d6;


### PR DESCRIPTION
On light theme, unread items in a watched repo have a blue stripe on the left edge. This is currently missing from the dark theme

<img width="1289" alt="Screen Shot 2020-11-20 at 5 58 07 PM" src="https://user-images.githubusercontent.com/25715018/99792945-7b436f00-2b5a-11eb-86a6-745c12011cbf.png">

In dark theme - Before the fix

<img width="825" alt="Screen Shot 2020-11-20 at 5 55 38 PM" src="https://user-images.githubusercontent.com/25715018/99792943-7a124200-2b5a-11eb-969a-2f1a3a0dee75.png">

In dark theme - After the fix

<img width="828" alt="Screen Shot 2020-11-20 at 5 55 09 PM" src="https://user-images.githubusercontent.com/25715018/99792937-767ebb00-2b5a-11eb-8829-06371006dfce.png">