### PR TITLE
allow background color to bleed when body is shorter than viewport

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -1,5 +1,9 @@
 /* # Layout */
 
+html {
+    background-color: inherit;
+}
+
 body {
     background-color: $bg-color !important;
     color: $text-color !important;


### PR DESCRIPTION
Hi!

Thank you for the great dark theme.

Found a small bug. When the `body` is shorter than the viewport, I am seeing a large white background on the bottom. 

Turns out is a weird quirk `html` vs `body` and background color bleed: https://css-tricks.com/html-vs-body-in-css/#quirky-background-color

Before:
<img width="1836" alt="Screen Shot 2020-12-09 at 2 28 34 PM" src="https://user-images.githubusercontent.com/16548879/101696417-ee8a2380-3a2a-11eb-9beb-d06a6c3d0206.png">

After
<img width="1838" alt="Screen Shot 2020-12-09 at 2 28 55 PM" src="https://user-images.githubusercontent.com/16548879/101696430-f34ed780-3a2a-11eb-9772-23ba74cf1786.png">
