### PR TITLE
fix: improve contrast of notification action buttons

### DIFF
--- a/src/theme/notifications.scss
+++ b/src/theme/notifications.scss
@@ -71,3 +71,6 @@ summary.text-gray {
     background-color: $border-color !important;
 }
 
+.notifications-list-item:hover .notification-list-item-actions li.js-notification-action .btn .octicon {
+    color: $text-color !important;
+}


### PR DESCRIPTION
Fixes the text color of action buttons on the Notifications page.

---
Before

![Screenshot from 2020-12-17 10-37-38](https://user-images.githubusercontent.com/25715018/102441212-6d4b1600-4054-11eb-8f67-c9ccd107325a.png)

After

![Screenshot from 2020-12-17 10-36-42](https://user-images.githubusercontent.com/25715018/102441206-6b815280-4054-11eb-82bc-00bb203265c8.png)


