### PR TITLE
Fix incorrect background color for actions summary

### DIFF
--- a/src/theme/misc.scss
+++ b/src/theme/misc.scss
@@ -212,6 +212,15 @@ img.network-tree {
     color: $text-green-color !important;
 }
 
+/* Actions summary view */
+div.actions-fullwidth-module {
+    background-color: $block-bg !important;
+}
+
+div.p-2 div.color-bg-canvas-inset, .WorkflowJob {
+    background-color: $file-row-active-bg !important;
+}
+
 /* Various Buttons: "Code" dropdown links, etc */
 .UnderlineNav-item {
     color: inherit !important;


### PR DESCRIPTION
Closes https://github.com/poychang/github-dark-theme/issues/333

Before | After
------------ | -------------
![Before](   https://i.imgur.com/lpbL1Nt.png ) | ![After]( https://i.imgur.com/FetSCoJ.png   )  |


The white edges come from the `.rounded-2` class on the element and I'm not sure what would be a good way to go about getting rid of that.

On another note this PR highlights the poor contrast of some text colors used such as the "49s" that is shown within the build box. I think that the `$text-color` color variable should be lightned as in this case it really shows how hard it is to read. I'ts also lacking in many other places where it's used for text.