### PR TITLE
fix: background color of some sections

### DIFF
--- a/src/theme/diff.scss
+++ b/src/theme/diff.scss
@@ -99,3 +99,30 @@ tr:not(.blob-expanded) + .blob-expanded .blob-num {
     }
 }
 
+.js-suggested-changes-blob {
+    .blob-num-addition {
+        background-color: $diff-addition !important;
+        border-color: $border-color !important;
+    }
+
+    .blob-code-addition {
+        background-color: $diff-addition !important;
+        .x {
+            color: $diff-accent-font-color !important;
+            background-color: $diff-addition-accent !important;
+        }
+    }
+
+    .blob-num-deletion {
+        background-color: $diff-deletion !important;
+        border-color: $border-color !important;
+    }
+
+    .blob-code-deletion {
+        background-color: $diff-deletion !important;
+        .x {
+            color: $diff-accent-font-color !important;
+            background-color: $diff-deletion-accent !important;
+        }
+    }
+}

--- a/src/theme/elements.scss
+++ b/src/theme/elements.scss
@@ -19,6 +19,9 @@ body {
     .bg-white {
         background-color: $bg-color !important;
     }
+    .color-bg-secondary {
+        background-color: $bg-color !important;
+    }
     .pagination {
         a,
         em:focus,
@@ -169,7 +172,6 @@ body {
         border-top-color: $block-bg !important;
     }
 
-
     .Popover-message:before {
         border-bottom-color: $border-color !important;
     }
@@ -182,7 +184,6 @@ body {
         background-color: $dropdown-bg !important;
         color: $text-color !important;
     }
-
 }
 
 .cc-ext .pagehead-actions .cc-classic-cta a {

--- a/src/theme/elements.scss
+++ b/src/theme/elements.scss
@@ -22,6 +22,9 @@ body {
     .color-bg-secondary {
         background-color: $bg-color !important;
     }
+    .color-text-secondary {
+        color: $text-color !important;
+    }
     .pagination {
         a,
         em:focus,


### PR DESCRIPTION
Hi 🙂 

I hope the repo is still being maintained for those who are not ready for GitHub dark mode (until they reduce the contrast!).

Apparently GitHub has changed the HTML a bit, causing the overriding styles not being applied correctly. This can be reproduced by accessing GitHub without being logged in, or using the extension but switch off GitHub dark mode.

### Screenshots

| Section | Before | After |
| --- | --- | --- |
| Repo top bar | <img width="1680" alt="Screen Shot 2021-02-27 at 18 21 18" src="https://user-images.githubusercontent.com/25715018/109386426-15227100-792d-11eb-9ce3-227378eefad6.png"> | <img width="1680" alt="Screen Shot 2021-02-27 at 18 20 08" src="https://user-images.githubusercontent.com/25715018/109386435-223f6000-792d-11eb-804f-8685ca7e6a41.png"> |
| Comment box | <img width="862" alt="Screen Shot 2021-02-27 at 18 21 36" src="https://user-images.githubusercontent.com/25715018/109386461-5155d180-792d-11eb-87df-5b6ea0845cca.png"> | <img width="868" alt="Screen Shot 2021-02-27 at 18 22 10" src="https://user-images.githubusercontent.com/25715018/109386468-5adf3980-792d-11eb-9cee-42c34c85e58d.png"> |
| File finder | <img width="1280" alt="Screen Shot 2021-02-27 at 18 50 28" src="https://user-images.githubusercontent.com/25715018/109386471-63377480-792d-11eb-9cc4-997e5b642513.png"> | <img width="1285" alt="Screen Shot 2021-02-27 at 18 49 48" src="https://user-images.githubusercontent.com/25715018/109386477-71859080-792d-11eb-818f-7dfadaa1a175.png"> |
| Suggested changes | <img width="752" alt="Screen Shot 2021-02-27 at 18 38 30" src="https://user-images.githubusercontent.com/25715018/109386445-33886c80-792d-11eb-8f56-264d21f793a5.png"> | <img width="762" alt="Screen Shot 2021-02-27 at 18 35 46" src="https://user-images.githubusercontent.com/25715018/109386452-3edb9800-792d-11eb-952b-39d9e82768f3.png"> |
| Text color | <img width="374" alt="Screen Shot 2021-02-28 at 04 55 09" src="https://user-images.githubusercontent.com/25715018/109401425-33b25780-7981-11eb-92ad-fe3751825d58.png"> | <img width="377" alt="Screen Shot 2021-02-28 at 04 51 59" src="https://user-images.githubusercontent.com/25715018/109401388-edf58f00-7980-11eb-8bd4-08217bc407b7.png"> | 

