### PR TITLE
fix: tooltip color and timeline background color

### DIFF
--- a/src/theme/profile.scss
+++ b/src/theme/profile.scss
@@ -162,3 +162,12 @@ span.color-bg-primary {
 div.color-bg-primary {
     background-color: $bg-color !important;
 }
+
+/* Tooltip on the activity graph */
+.svg-tip strong {
+    color: inherit !important;
+}
+
+.color-bg-default {
+    background-color: inherit !important;
+}


### PR DESCRIPTION
## Description

This PR fixes the tooltip color and the timeline background color on the profile page (when using the extension with a GitHub dark theme).

## Screenshot

| Note | Before | After | 
| --- | --- | --- |
| With GitHub dark default | <img width="292" alt="Screen Shot 2022-01-25 at 14 02 41" src="https://user-images.githubusercontent.com/25715018/150932748-3367206f-fa93-45e5-898e-204fc9ae0f4a.png"> | <img width="280" alt="Screen Shot 2022-01-25 at 13 57 40" src="https://user-images.githubusercontent.com/25715018/150932776-2209a153-5d7b-4220-b0d3-30b1ad33b4d5.png"> |
| With GitHub dark high contrast | <img width="264" alt="Screen Shot 2022-01-25 at 14 58 46" src="https://user-images.githubusercontent.com/25715018/150935442-babb7344-4ae3-45c6-bcee-252e79601a3c.png"> | <img width="257" alt="Screen Shot 2022-01-25 at 14 54 38" src="https://user-images.githubusercontent.com/25715018/150935306-725aefaf-cfc5-421e-9915-c6500121b09b.png"> |
| Timeline | <img width="942" alt="Screen Shot 2022-01-25 at 14 01 51" src="https://user-images.githubusercontent.com/25715018/150933417-9ca91051-9228-4111-af0b-568f3d802424.png"> | <img width="923" alt="Screen Shot 2022-01-25 at 14 02 10" src="https://user-images.githubusercontent.com/25715018/150933464-9e2fbf17-ec45-405c-820c-4ac8c1f10512.png"> |