### PR TITLE
fix: text color and link display

### DIFF
--- a/src/theme/discussions.scss
+++ b/src/theme/discussions.scss
@@ -211,9 +211,16 @@ body {
         border-color: $border-color !important;
     }
     .timeline-comment {
-        color: $text-color !important;
         background-color: $comment-bg !important;
         border-color: $border-color !important;
+        
+        .comment-body {
+            color: $text-color !important;
+
+            a {
+                text-decoration: underline;
+            }
+        }
 
         &.current-user {
             background-color: $comment-bg !important;


### PR DESCRIPTION
## Description

There are two issues we have regarding text display:
1. No differences between monospace text and link with monospace
2. No differences between plain text and link

Since `$text-color` and `$link-color` are quite similar (`#9da5b4` vs `#d6d8da`), users with visual disabilities might have difficulties in differentiating between the two. I'm fixing the issue by adding an underline to the `a` element. 

Not sure if you're happy with this, but another option we have is to change `$link-color` to a blue color.

Closes #375 

## Screenshot

| Without the extension | With the extension (before) | With the extension (after) |
| --- | --- | --- |
| <img width="859" alt="Screen Shot 2022-09-18 at 17 54 07" src="https://user-images.githubusercontent.com/25715018/190898723-5d12cd8d-a931-4253-8bbb-08c35e615911.png"> | <img width="862" alt="Screen Shot 2022-09-18 at 17 53 30" src="https://user-images.githubusercontent.com/25715018/190898732-a742eea6-ab03-4441-93b8-fd5dd65d5030.png"> | <img width="859" alt="Screen Shot 2022-09-18 at 17 54 27" src="https://user-images.githubusercontent.com/25715018/190898742-0a60ba2c-b92b-4d93-b240-9be6717acd7f.png"> |