### PR TITLE
fix: repo badge border

### DIFF
--- a/src/theme/layout.scss
+++ b/src/theme/layout.scss
@@ -33,14 +33,6 @@ body {
         background: $head-bg !important;
         border-color: $border-color !important;
     }
-    /* Repo label (i.e. Private, Archived) */
-    .Label {
-        &.Label--outline,
-        &.Label--gray {
-            color: $text-color !important;
-            border-color: $light-border-color !important;
-        }
-    }
     .site-header {
         background: $head-bg !important;
         border-color: $border-color !important;

--- a/src/theme/organization.scss
+++ b/src/theme/organization.scss
@@ -23,8 +23,22 @@
     }
 }
 
+.pinned-item-list-item {
+    & .Label--secondary {
+        color: $text-color !important;
+        border-color: $light-border-color !important;
+    }
+}
+
 .Box-row--gray {
     background-color: $comment-bg !important;
+}
+
+.Box-row {
+    & .Label--secondary {
+        color: $text-color !important;
+        border-color: $light-border-color !important;
+    }
 }
 
 .menu-heading {


### PR DESCRIPTION
## Description

Fixes the border color of repo badge on the organization page.

## Screenshot

Check the border of the "Public" badge.

| Before | After | 
| --- | --- |
| <img width="916" alt="Screen Shot 2022-09-19 at 01 27 54" src="https://user-images.githubusercontent.com/25715018/190922757-d26c0f9a-9574-4723-9132-1b35fc26303f.png"> | <img width="914" alt="Screen Shot 2022-09-19 at 01 20 48" src="https://user-images.githubusercontent.com/25715018/190922999-dde73657-33eb-48ed-b487-49f2cff78326.png"> |
| <img width="891" alt="Screen Shot 2022-09-19 at 01 28 04" src="https://user-images.githubusercontent.com/25715018/190922771-dd6a1c05-3367-4655-a995-97bd71ea8520.png"> | <img width="891" alt="Screen Shot 2022-09-19 at 01 21 04" src="https://user-images.githubusercontent.com/25715018/190922722-bdc262c0-5519-4f20-af1f-16b93fb600bd.png"> |